### PR TITLE
FS-1428; Move helm chart to fleet-scheduler

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,0 +1,31 @@
+name: Release Charts
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    name: Publish Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      -
+        name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: .
+          config: 
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ A **job** is a task that is set up to be executed on a schedule through a [k8s c
 ```
 ## Usage within sandbox
 
-Fleet Scheduler jobs can be created within the value.yaml file of the [sandbox](https://github.com/metal-toolbox/sandbox).
+Sandbox will include the [helm chart](https://github.com/metal-toolbox/fleet-scheduler/tree/main/chart) by including it as a dependency in Chart.yaml
+
+Fleet Scheduler jobs can be created within the value.yaml.
 
 Each job requires a few values in order to function.
 
@@ -25,4 +27,6 @@ Each job requires a few values in order to function.
 
 ## Creating new jobs
 
-Explained in the sandbox [README](https://github.com/metal-toolbox/sandbox/blob/main/README.md) in the "Fleet Scheduler" section.
+Jobs can be created within the Sandbox, or within [values.yaml](https://github.com/metal-toolbox/fleet-scheduler/tree/main/chart/values.yaml) here.
+
+Explained in the sandbox [README](https://github.com/metal-toolbox/sandbox/blob/main/notes/fleet-scheduler.md).

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus-pushgateway
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 2.7.1
+digest: sha256:1a72f81c924e759c3591ca1bc97f8491d4fd4a4067ed40376d3fb4053d826cea
+generated: "2024-05-01T18:09:18.902786846-04:00"

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: prometheus-pushgateway
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 2.7.1
-digest: sha256:1a72f81c924e759c3591ca1bc97f8491d4fd4a4067ed40376d3fb4053d826cea
-generated: "2024-05-01T18:09:18.902786846-04:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: fleet-scheduler
+description: A chart for fleet scheduled cron jobs
+version: 1.0.1
+keywords:
+  - cron
+home: "https://github.com/metal-toolbox/fleet-scheduler"
+sources:
+  - "https://github.com/metal-toolbox/fleet-scheduler"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cronjobs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cronjobs.labels" -}}
+helm.sh/chart: {{ include "cronjobs.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Expand the release name of the chart.
+*/}}
+{{- define "cronjobs.releaseName" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+

--- a/chart/templates/_nil_check.tpl
+++ b/chart/templates/_nil_check.tpl
@@ -1,0 +1,11 @@
+{{- define "fleetscheduler.scheduleValueExists" -}}
+  {{- if .job.schedule -}}
+    {{- if index .job.schedule (printf "%s" .var) -}}
+      {{- index .job.schedule (printf "%s" .var) -}}
+    {{- else -}}
+      {{- .default -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .default -}}
+  {{- end -}}
+{{- end -}}

--- a/chart/templates/_random-scheduler.tpl
+++ b/chart/templates/_random-scheduler.tpl
@@ -1,0 +1,55 @@
+  {{/*
+    # uint64 max value is 20 digits. So 19 should be good to get a good big value for a random number with (randNumberic 19)
+
+    # Psuedo code to show what the template logic is doing below
+    # if enable_random_minute {
+    #     if (random_minute_span + minute) > 59 {
+    #         return error("random_minute_span and minute must not add up to more than 59")
+    #     }
+    #     if !minute.isNumber() {
+    #         return error("if enable_random_minute is true, minute must be a single number")
+    #     }
+    #     if !random_minute_span.isNumber() {
+    #         return error("if enable_random_minute is true, random_minute_span must be a single number")
+    #     }
+    #     if random_minute_span == 0 {
+    #         return error("random_minute_span must be greater than 0")
+    #     }
+    # } else if job.schedule.minute > 59 {
+    #     return error("minute must not be greater than 59")
+    # }
+    # calculated_minute = enable_random_minute ? minute + rand_uint64() % (random_minute_span + 1) : minute
+    # return calculated_minute
+
+    # .type: literal string of minute, hour, or day_of_week
+    # .var: either minute, hour, or day_of_week
+    # .span: either random_minute_span, random_hour_span, or random_day_of_week_span
+    # .limit: either 59 (for minutes), 23 (for hours), or 6 (for days_of_week)
+    # .enable: either enable_random_minute, enable_random_hour, enable_random_days_of_week
+  */}}
+
+{{- define "fleetscheduler.calculate" -}}
+  {{- if .enable -}}
+    {{- if gt (add .span .var) .limit -}}
+      {{- printf "if enabled, random_%s_span and %s must not add up to more than %d (was: %d)" .type .type .limit (add .span .var) | fail -}}
+    {{- end -}}
+    {{- if not (regexMatch "[0-9]+" .var) -}}
+      {{- printf "if enabled, %s must be a single number (was: %s)" .type .var | fail -}}
+    {{- end -}}
+    {{- if not (regexMatch "[0-9]+" .span) -}}
+      {{- printf "if enabled, random_%s_span must be a single number (was: %s)" .type .span | fail -}}
+    {{- end -}}
+    {{- if eq (atoi .span) 0 -}}
+      {{- printf "if enabled, random_%s_span must be greater than 0 (was: %s)" .type .span | fail -}}
+    {{- end}}
+  {{- else if gt (atoi .var) 59 -}}
+      {{- fail "%s must not be greater than %d" -}}
+      {{- printf "%s must not be greater than %d (was: %s)" .type .limit .var | fail -}}
+  {{- end -}}
+  {{- $calculated := ternary
+    (add .var (mod (randNumeric 19) (add1 .span)))
+    .var
+    (eq .enable "true")
+  -}}
+  {{- $calculated -}}
+{{- end -}}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.enable }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fleet-scheduler-config
+  namespace: {{ .Values.env.namespace }}
+data:
+  config.yaml: |
+    log_level: {{ .Values.env.log_level }}
+    facility_code: {{ tpl .Values.env.facility . }}
+    fleetdb_api:
+      disable_oauth: {{ not .Values.env.endpoints.fleetdb.authenticate }}
+      endpoint: {{ .Values.env.endpoints.fleetdb.url }}
+      oidc_client_id: {{ .Values.env.endpoints.fleetdb.oidc_client_id }}
+      oidc_audience_endpoint: {{ .Values.env.endpoints.fleetdb.oidc_audience_url}}
+      oidc_issuer_endpoint: {{ .Values.env.endpoints.fleetdb.oidc_issuer_url}}
+      oidc_scopes: {{ .Values.env.endpoints.fleetdb.oidc_scopes }}
+    conditionorc_api:
+      disable_oauth: {{ not .Values.env.endpoints.conditionorc.authenticate }}
+      endpoint: {{ .Values.env.endpoints.conditionorc.url }}
+      oidc_client_id: {{ .Values.env.endpoints.conditionorc.oidc_client_id }}
+      oidc_audience_endpoint: {{ .Values.env.endpoints.conditionorc.oidc_audience_url}}
+      oidc_issuer_endpoint: {{ .Values.env.endpoints.conditionorc.oidc_issuer_url}}
+      oidc_scopes: {{ .Values.env.endpoints.conditionorc.oidc_scopes }}
+{{ end }}

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -1,0 +1,114 @@
+{{ if .Values.enable }}
+{{ range $job := .Values.jobs }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $job.name }}
+  namespace: {{ $.Values.env.namespace }}
+  labels:
+    k8s-service: fleet-scheduler
+spec:
+  {{- with $job.deadline }}
+  startingDeadlineSeconds: {{ . }}
+  {{- end}}
+
+  # These "jitter" cronjob schedulers might be implemented properly within k8s in the future. If that happens we should look into using those instead.
+  # https://github.com/kubernetes/enhancements/blob/master/keps/sig-apps/19-Graduate-CronJob-to-Stable/README.md#support-jitter-for-cronjobs
+
+  {{ $minute := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "minute" "default" 0) }}
+  {{ $hour := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "hour" "default" 0) }}
+  {{ $month := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "month" "default" 0) }}
+  {{ $day_of_week := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "day_of_week" "default" 0) }}
+  {{ $enable_random_minute := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "enable_random_minute" "default" "") }}
+  {{ $random_minute_span := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "random_minute_span" "default" 0) }}
+  {{ $enable_random_hour := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "enable_random_hour" "default" "") }}
+  {{ $random_hour_span := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "random_hour_span" "default" 0) }}
+  {{ $enable_random_day_of_week := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "enable_random_day_of_week" "default" "") }}
+  {{ $random_day_of_week_span := include "fleetscheduler.scheduleValueExists" (dict "job" $job "var" "random_day_of_week_span" "default" 0) }}
+
+  # Minutes
+  {{ $calculated_minute := include "fleetscheduler.calculate" (dict
+    "enable" $enable_random_minute
+    "type" "minute"
+    "limit" 59
+    "var" $minute
+    "span" $random_minute_span
+  )}}
+  # Hours
+  {{ $calculated_hour := include "fleetscheduler.calculate" (dict
+    "enable" $enable_random_hour
+    "type" "hour"
+    "limit" 23
+    "var" $hour
+    "span" $random_hour_span
+  )}}
+  # Days of the week
+  {{ $calculated_day_of_week := include "fleetscheduler.calculate" (dict
+    "enable" $enable_random_day_of_week
+    "type" "day_of_week"
+    "limit" 6
+    "var" $day_of_week
+    "span" $random_day_of_week_span
+  )}}
+
+  schedule: {{ printf "%s %s * %s %s" $calculated_minute $calculated_hour $job.schedule.month $calculated_day_of_week | quote }}
+
+  jobTemplate:
+    spec:
+      {{- with $job.ttl }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end}}
+      template:
+        metadata:
+          labels:
+            k8s-app: fleet-scheduler
+        spec:
+          restartPolicy: {{ $job.restartPolicy }}
+          {{- if or $.Values.env.endpoints.fleetdb.authenticate $.Values.env.endpoints.conditionorc.authenticate }}
+          imagePullSecrets:
+            - name: fleet-scheduler-secrets
+          {{- end }}
+          volumes:
+            - name: config-volume
+              configMap:
+                name: fleet-scheduler-config
+          containers:
+          - name: {{ $job.name }}
+            image: {{ $.Values.image.repository.url }}/fleet-scheduler:{{ $.Values.image.repository.tag }}
+            imagePullPolicy: {{ $.Values.image.pullPolicy }}
+            {{- with $job.command }}
+            command:
+{{ toYaml . | indent 12 }}
+              {{- end }}
+            volumeMounts:
+              - name: config-volume
+                mountPath: /etc/fleet-scheduler
+                readOnly: true
+            env:
+              - name: FLEET_SCHEDULER_CONFIG
+                value: "/etc/fleet-scheduler/config.yaml"
+              {{- if $.Values.env.endpoints.fleetdb.authenticate }}
+              - name: FLEET_SCHEDULER_FLEETDB_OIDC_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: fleet-scheduler-secrets
+                    key: fleetdb-oidc-client-secret
+              {{- end }}
+              {{- if $.Values.env.endpoints.conditionorc.authenticate }}
+              - name: FLEET_SCHEDULER_CONDITIONORC_OIDC_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: fleet-scheduler-secrets
+                    key: conditionorc-oidc-client-secret
+              {{- end }}
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 1000Mi
+              requests:
+                cpu: 2000m
+                memory: 1000Mi
+          activeDeadlineSeconds: 10800
+---
+{{ end }}
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,47 @@
+image:
+  pullPolicy: Always
+  repository:
+    tag: latest
+    url: localhost:5001
+env:
+  namespace: default
+  facility: sandbox
+  log_level: debug
+  endpoints:
+    fleetdb:
+      authenticate: true
+      url: http://fleetdb:8000
+      oidc_audience_url: # to be filled by parent helm chart if authenticate is true
+      oidc_issuer_url:   # to be filled by parent helm chart if authenticate is true
+      oidc_client_id: # to be filled by parent helm chart if authenticate is true
+      oidc_scopes:    # to be filled by parent helm chart if authenticate is true
+    conditionorc:
+      authenticate: true
+      url: http://conditionorc-api:9001
+      oidc_audience_url: # to be filled by parent helm chart if authenticate is true
+      oidc_issuer_url:   # to be filled by parent helm chart if authenticate is true
+      oidc_client_id: # to be filled by parent helm chart if authenticate is true
+      oidc_scopes:    # to be filled by parent helm chart if authenticate is true
+enable: true # can be entirely disabled by flipping this to false. It will still deploy, but it will not execute any tasks
+jobs:
+  - name: inventory # This job will collect all servers and create conditions on them within the facility
+    ttlSecondsAfterFinished: 86400 # Remove job after 1 day. (optional)
+    restartPolicy: Never
+    schedule: # Run every monday, starting at 12pm UTC, and randomly running over the next 6 hours
+      minute: "0"
+      hour: "12"
+      month: "*" # run every month
+      day_of_week: "1"
+      enable_random_minute: true # run randomly between all minutes between the range schedule.minute and (schedule.minute + schedule.random_minute_span)
+      random_minute_span: "58" # run anytime 59 minutes after the start minutes
+      enable_random_hour: true # run randomly between all hours between the range schedule.hour and (schedule.hour + schedule.random_hour_span)
+      random_hour_span: "6" # run anytime 6 hours after the start hour
+      enable_random_day_of_week: true # run randomly throughout the work week (monday through friday)
+      random_day_of_week_span: "5"
+    command:
+    - /usr/sbin/fleet-scheduler
+    - --config
+    - /etc/fleet-scheduler/config.yaml
+    - inventory
+    - --page-size # how many servers to get per request to fleetdb
+    - "100"

--- a/internal/metrics/custom_metrics.go
+++ b/internal/metrics/custom_metrics.go
@@ -14,7 +14,7 @@ func init() {
 		prometheus.CounterOpts{
 			Namespace: "fleet-scheduler",
 			Subsystem: "conditionorc",
-			Name:      "errors_total",
+			Name:      "fleet_scheduler_conditionorc_errors",
 			Help:      "a count of all errors attempting to reach conditionorc",
 		}, []string{
 			"errors",
@@ -25,7 +25,7 @@ func init() {
 		prometheus.CounterOpts{
 			Namespace: "fleet-scheduler",
 			Subsystem: "fleetdb",
-			Name:      "errors_total",
+			Name:      "fleet_scheduler_fleetdb_errors",
 			Help:      "a count of all errors attempting to reach fleetdb",
 		}, []string{
 			"errors",
@@ -36,7 +36,7 @@ func init() {
 		prometheus.CounterOpts{
 			Namespace: "fleet-scheduler",
 			Subsystem: "core",
-			Name:      "errors_total",
+			Name:      "fleet_scheduler_inventory_count",
 			Help:      "a count of all errors attempting to reach fleet-scheduler dependencies",
 		}, []string{},
 	)


### PR DESCRIPTION
#### What does this PR do

Moving the bulk of the helm chart for fleet-scheduler into the fleet-scheduler repo. Allows easier control of the configuration, and a single truth for what the helm chart is.
