### PR TITLE
Fix Helm Chart Release

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sed -i "s/VERSION/${{ github.ref_name }}/g" ./${{ env.CHART_NAME }}/chart/Chart.yaml
           helm package ./${{ env.CHART_NAME }}/chart -u -d ./helm-charts/
-          helm repo index ./helm-charts/ --url https://metal-toolbox.github.io/helm-charts/
+          helm repo index ./helm-charts/ --url https://metal-toolbox.github.io/${{ env.CHART_NAME }}/
       -
         name: Create Git Commit
         run: |

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -9,23 +9,48 @@ jobs:
   build:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      CHART_NAME: fleet-scheduler
     steps:
       -
         name: Checkout
         uses: actions/checkout@v4
         with:
+          path: ${{ env.CHART_NAME }}
           fetch-depth: 0
       -
-        name: Configure Git
+        name: Checkout Helm chart Repo
+        uses: actions/checkout@v4
+        with:
+          repository: metal-toolbox/${{ env.CHART_NAME }}
+          path: helm-charts
+          ref: gh-pages
+          fetch-depth: 0
+      -
+        name: Install Helm
+        uses: azure/setup-helm@v4.2.0
+      -
+        name: Package Helm Chart
         run: |
+          sed -i "s/VERSION/${{ github.ref_name }}/g" ./${{ env.CHART_NAME }}/chart/Chart.yaml
+          helm package ./${{ env.CHART_NAME }}/chart -u -d ./helm-charts/
+          helm repo index ./helm-charts/ --url https://metal-toolbox.github.io/helm-charts/
+      -
+        name: Create Git Commit
+        run: |
+          cd helm-charts
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add index.yaml *.tgz
+          git commit -m "published ${{ env.CHART_NAME }}-${{ github.ref_name }}.tgz"
       -
-        name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        name: Push Changes
+        uses: ad-m/github-push-action@master
         with:
-          charts_dir: .
-          config: 
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"
+          repository: metal-toolbox/${{ env.CHART_NAME }}
+          directory: helm-charts
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release Fleet-Scheduler
 
 on:
   push:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fleet-scheduler
 description: A chart for fleet scheduled cron jobs
-version: 1.0.1
+version: VERSION # To be updated by github action when tag is created
 keywords:
   - cron
 home: "https://github.com/metal-toolbox/fleet-scheduler"


### PR DESCRIPTION
#### What does this PR do
Fix the helm chart release. It now deploys helm charts to fleet-schedulers gh-page branch when you tag a release of fleet-scheduler. Using the same version tag that the build uses