### PR TITLE
FS-1723; Fix config struct pointer issue

### DIFF
--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -85,17 +85,15 @@ spec:
                 mountPath: /etc/fleet-scheduler
                 readOnly: true
             env:
-              - name: FLEET_SCHEDULER_CONFIG
-                value: "/etc/fleet-scheduler/config.yaml"
               {{- if $.Values.env.endpoints.fleetdb.authenticate }}
-              - name: FLEET_SCHEDULER_FLEETDB_OIDC_CLIENT_SECRET
+              - name: ENDPOINTS_FLEETDB_OIDC_CLIENT_SECRET
                 valueFrom:
                   secretKeyRef:
                     name: fleet-scheduler-secrets
                     key: fleetdb-oidc-client-secret
               {{- end }}
               {{- if $.Values.env.endpoints.conditionorc.authenticate }}
-              - name: FLEET_SCHEDULER_CONDITIONORC_OIDC_CLIENT_SECRET
+              - name: ENDPOINTS_CONDITIONORC_OIDC_CLIENT_SECRET
                 valueFrom:
                   secretKeyRef:
                     name: fleet-scheduler-secrets

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -19,7 +19,7 @@ const (
 // Values are then grabbed from the ENV variables, anything found will be used to override values in the config file.
 // Example: Setting Configuration.Endpoints.FleetDB.URL
 // In the config file (as yaml); endpoints.fleetdb.url: http://fleetdb:8000
-// As a ENV variable; FLIPFLOP_ENDPOINTS_FLEETDB_URL=http://fleetdb:8000
+// As a ENV variable; ENDPOINTS_FLEETDB_URL=http://fleetdb:8000
 type Configuration struct {
 	// FacilityCode limits this flipflop to events in a facility.
 	FacilityCode string `mapstructure:"facility"`
@@ -34,10 +34,10 @@ type Configuration struct {
 
 type Endpoints struct {
 	// FleetDBConfig defines the fleetdb client configuration parameters
-	ConditionOrc *ConfigOIDC `mapstructure:"conditionorc"`
+	ConditionOrc ConfigOIDC `mapstructure:"conditionorc"`
 
 	// FleetDBConfig defines the fleetdb client configuration parameters
-	FleetDB *ConfigOIDC `mapstructure:"fleetdb"`
+	FleetDB ConfigOIDC `mapstructure:"fleetdb"`
 }
 
 type ConfigOIDC struct {

--- a/internal/client/clients.go
+++ b/internal/client/clients.go
@@ -58,7 +58,7 @@ func (c *Client) newFleetDBClient() error {
 	var secret string
 	if c.cfg.Endpoints.FleetDB.Authenticate {
 		secret = c.cfg.Endpoints.FleetDB.OidcClientSecret
-		client, err = c.setUpClientWithOAuth(c.cfg.Endpoints.FleetDB)
+		client, err = c.setUpClientWithOAuth(&c.cfg.Endpoints.FleetDB)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func (c *Client) newConditionOrcClient() error {
 	var secret string
 	if c.cfg.Endpoints.ConditionOrc.Authenticate {
 		secret = c.cfg.Endpoints.ConditionOrc.OidcClientSecret
-		client, err = c.setUpClientWithOAuth(c.cfg.Endpoints.ConditionOrc)
+		client, err = c.setUpClientWithOAuth(&c.cfg.Endpoints.ConditionOrc)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What does this PR do

- Renaming ENV variables so they are correctly grabbed
- Remove endpoint config struct pointers, pointers aren't correctly mapped by `bindEnvVars`